### PR TITLE
Fix invalid CSS selector

### DIFF
--- a/src/less/overrides.less
+++ b/src/less/overrides.less
@@ -363,11 +363,11 @@ This will need to be resolved if TFOOT becomes necessary
     &:not(:first-child) {
       .box-shadow(0 6px 6px -6px rgba(0,0,0,.16) inset);
     }
-    > &:first-child {
+    &:first-child {
       border: none;
       .border-top-radius(@border-radius-base);
     }
-    > &:last-child {
+    &:last-child {
       .border-bottom-radius(@border-radius-base);
     }
   }


### PR DESCRIPTION
This fixes warnings in our (RDW) build:
```
WARNING in Invalid selector '>.well-group .well:first-child' at 4843:166660. Ignoring.

WARNING in Invalid selector '>.well-group .well:last-child' at 4843:166758. Ignoring.

WARNING in Invalid selector '> .well-group .well:first-child' at 20113:1. Ignoring.

WARNING in Invalid selector '> .well-group .well:last-child' at 20117:1. Ignoring.
```